### PR TITLE
Test vehicle change

### DIFF
--- a/ArduPlane/afs_plane.cpp
+++ b/ArduPlane/afs_plane.cpp
@@ -4,6 +4,8 @@
 
 #include "Plane.h"
 
+// this is a plane change
+
 #if ADVANCED_FAILSAFE == ENABLED
 
 /*


### PR DESCRIPTION
Test plane change, should skip checks for copter, rover, tracker, periph and replay.